### PR TITLE
Fix "Overworld cannot be null!" for 1.18.2

### DIFF
--- a/internal/v1_18_R2/src/main/java/net/flawe/offlinemanager/api/util/v1_18_R2/data/OfflineUser.java
+++ b/internal/v1_18_R2/src/main/java/net/flawe/offlinemanager/api/util/v1_18_R2/data/OfflineUser.java
@@ -114,7 +114,7 @@ public class OfflineUser implements IUser {
     }
 
     private WorldServer getWorldServer() {
-        return getMinecraftServer().a(World.f);
+        return getMinecraftServer().a(World.e);
     }
 
     @Override
@@ -236,4 +236,3 @@ public class OfflineUser implements IUser {
         }
     }
 }
-

--- a/internal/v1_18_R2/src/main/java/net/flawe/offlinemanager/api/util/v1_18_R2/data/PlayerData.java
+++ b/internal/v1_18_R2/src/main/java/net/flawe/offlinemanager/api/util/v1_18_R2/data/PlayerData.java
@@ -88,7 +88,7 @@ public class PlayerData extends AbstractPlayerData {
         this.api = api;
         this.uuid = profile.getUuid();
         MinecraftServer server = ((CraftServer) Bukkit.getServer()).getServer();
-        WorldServer worldServer = server.a(World.f);
+        WorldServer worldServer = server.a(World.e);
         if (worldServer == null)
             throw new NullPointerException("Overworld cannot be null!");
         GameProfile gameProfile = new GameProfile(uuid, profile.getName());
@@ -120,7 +120,7 @@ public class PlayerData extends AbstractPlayerData {
             return;
         }
         MinecraftServer server = ((CraftServer) Bukkit.getServer()).getServer();
-        WorldServer worldServer = server.a(World.f);
+        WorldServer worldServer = server.a(World.e);
         if (worldServer == null)
             throw new NullPointerException("Overworld cannot be null!");
         GameProfile profile = new GameProfile(uuid, Bukkit.getOfflinePlayer(uuid).getName());


### PR DESCRIPTION
It seems that `net.minecraft.world.level.World#f` got renamed to `net.minecraft.world.level.World#e`.
In 1.18.2 `World#f` seems to refer to `the_nether` but `World#e` refers to `overworld`.

Already tested on a Paper server with the following version:
```
Paper version git-Paper-347 (MC: 1.18.2) (Implementing API version 1.18.2-R0.1-SNAPSHOT) (Git: 79e07f3)
```
All the commands seem to work properly.
Perhaps it would be a good idea to test on a Spigot server as well.

This fixes #5 